### PR TITLE
Fixed sagetv.device.parent.<parent_id>.channel_map=

### DIFF
--- a/distribution/RELEASE.md
+++ b/distribution/RELEASE.md
@@ -1611,3 +1611,6 @@
 
 > *Added ability to tune Virtual Channels for Clear QAM lineups without
 > a CableCARD for reference.
+
+> *Fixed sagetv.device.parent.<parent_id>.channel_map=. The value wasn't
+> being read from properties and could not be set.

--- a/src/main/java/opendct/tuning/hdhomerun/HDHomeRunDiscoveredDeviceParent.java
+++ b/src/main/java/opendct/tuning/hdhomerun/HDHomeRunDiscoveredDeviceParent.java
@@ -47,7 +47,7 @@ public class HDHomeRunDiscoveredDeviceParent extends NetworkDiscoveredDevicePare
         while(true) {
             try {
                 channelMap = new StringDeviceOption(
-                        "",
+                        Config.getString(propertiesDeviceParent + "channel_map", ""),
                         false,
                         "Channel Map",
                         propertiesDeviceParent + "channel_map",


### PR DESCRIPTION
Fixes issue #353.