### PR TITLE
Applies security fixes for Log4J library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ ext {
     winWixConfig = 'build/wix/config'
 
     ffmpegVersion = '2.8.1-1.1'
-    log4jVersion = '2.5'
+    log4jVersion = '2.17.1'
     jnaVersion = '4.2.1'
 
     versionText = new File('src/main/java/opendct/config/StaticConfig.java').text


### PR DESCRIPTION
Applies a version change to the Log4J library in order to address CVE-2021-44228 (aka Log4Shell), CVE-2021-45046, CVE-2021-45105 and CVE-2021-44832. For further info see https://logging.apache.org/log4j/2.x/security.html.